### PR TITLE
Refine styling and add semantic hooks

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,13 +8,13 @@
   <style>
 :root{
   --parchment:#F6F1EB;
-  --card:#FFFFFF;
+  --card:#FFFEFC;
   --sepia:#5C4433;
   --sage:#9CAB86;
   --mauve:#A1918B;
   --ink:#2E2A27;
   --muted:#7A6D66;
-  --border:#EDE5DB;
+  --border:#E7DED4;
   --pill:#EEF2EA;
   --gap:16px;
   --pad:16px;
@@ -23,7 +23,9 @@
   --shadow-1:0 1px 2px rgba(0,0,0,.05);
   --shadow-2:0 8px 24px rgba(0,0,0,.08);
   --font: "SF Pro Text", -apple-system, system-ui, "Segoe UI", Roboto, Arial, sans-serif;
-  --railW: clamp(320px, 26vw, 420px); /* more room without blowing up on big screens */
+  --railW: clamp(360px, 28vw, 460px); /* more room without blowing up on big screens */
+  --ring:#C7D7C5;
+  --soft:#F7F3EE;
 }
 *{box-sizing:border-box}
 html,body{height:100%}
@@ -67,10 +69,9 @@ body{
 .status-left .dot{ width:8px; height:8px; background:var(--sage); border-radius:999px; display:inline-block; }
 .status-left b{ font-weight:700; }
 .card{ background:var(--card); border:1px solid var(--border); border-radius:var(--radius); padding:var(--pad); box-shadow:var(--shadow-1); }
-.card{ background:#FFFEFC; }
 .tag{ background:#FBF6F1; border-color:#EADFD3; }
 .tag[aria-pressed="true"]{ background:#EEF5EE; border-color:#D8E7D8; }
-.card-head{ display:flex; align-items:center; justify-content:space-between; margin-bottom:12px; }
+.card-head{ display:flex; align-items:center; justify-content:space-between; padding-bottom:6px; }
 .card-title{ font-weight:700; font-size:22px; }
 .btn{ font-weight:700; border-radius:999px; padding:8px 14px; border:1px solid transparent; background:transparent; color:var(--sepia); cursor:pointer; }
 .btn:active{ transform:translateY(1px) }
@@ -78,15 +79,15 @@ body{
 .btn-ghost{ background:transparent; border:1px solid var(--border); }
 .btn-icon{ width:28px;height:28px;padding:0;display:inline-flex;align-items:center;justify-content:center; }
 .hint{ color:var(--muted); font-size:15px; margin-top:8px; }
-:focus-visible{ outline:2px solid #7FB086; outline-offset:2px; border-radius:12px }
+:focus-visible{ outline:2px solid var(--ring); outline-offset:2px; border-radius:12px; }
 
 /* ---- Weather ---- */
 .weather-hero .now{ display:flex; align-items:baseline; gap:10px; }
 .weather-hero .temp{ font-size:40px; font-weight:800; }
 .weather-hero .cond{ font-size:17px; color:var(--muted); }
 .weather-hero .stats{ display:flex; gap:16px; color:var(--muted); margin-top:6px; }
-.mini{ display:grid; grid-template-columns:repeat(5,1fr); gap:12px; margin-top:12px; }
-.mini .cell{ background:#FAF9F7; border:1px solid var(--border); border-radius:12px; padding:10px; text-align:center; }
+.mini{ display:grid; grid-template-columns:repeat(5,1fr); gap:10px; margin-top:12px; }
+.mini .cell{ background:var(--soft); border:1px solid var(--border); border-radius:12px; padding:10px; text-align:center; }
 .mini .t{ font-size:12px; color:var(--muted); }
 .mini .v{ font-weight:700; }
 .weather-hero.loading .now,.weather-hero.loading .stats,.weather-hero.loading .mini{ opacity:.5; }
@@ -100,23 +101,6 @@ body{
 .field input{ height:48px; width:100%; border-radius:12px; border:1px solid var(--border); padding:10px 12px; font:inherit; color:var(--sepia); background:#fff; }
 .switch{ display:flex; align-items:center; gap:10px; }
 
-/* ---- Timeline ---- */
-.timeline{display:flex;flex-direction:column;gap:12px;position:relative}
-.timeline.dense{ gap:8px }
-.step{display:grid;grid-template-columns:64px 1fr;gap:12px;align-items:center;position:relative}
-.step::before{content:"";position:absolute;left:31px;top:-14px;bottom:-14px;width:2px;background:var(--border)}
-.step:first-child::before{display:none}
-.time-node{width:44px;height:44px;border-radius:999px;background:#FFF;border:1px solid var(--border);box-shadow:var(--shadow-1);display:flex;flex-direction:column;align-items:center;justify-content:center}
-.time-node .hhmm{ font-weight:800; font-size:15px }
-.time-node .ampm{font-size:11px;color:var(--muted);margin-top:-2px}
-.cardlet{background:#FAF9F7;border:1px solid var(--border);border-radius:16px;min-height:64px;padding:10px 12px;display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
-.cardlet .label{ font-weight:600; white-space:normal; }
-.cardlet .meta{ display:block; margin-top:2px; color:var(--muted) }
-.meta{font-size:13px;color:var(--muted)}
-.step.past .cardlet{opacity:.6}
-.step.now .cardlet{ border-color:color-mix(in oklab,var(--sage) 40%, var(--border)); box-shadow:0 0 0 2px color-mix(in oklab,var(--sage) 28%, transparent) }
-.step.done .time-node{background:var(--sage);color:#fff;border-color:var(--sage)}
-.step.done .cardlet{opacity:.6;text-decoration:line-through}
 
 /* ---- Backpacks ---- */
 .backpack-grid{display:grid;grid-template-columns:1fr 1fr;gap:var(--gap)}
@@ -133,32 +117,6 @@ body{
 .today-tags{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
 .subtle{ color:var(--muted); }
 
-/* ---- Med card (SVG bottle + states) ---- */
-.cardlet.med{
-  min-height: 96px; border-radius: 20px; display:grid; grid-template-columns: 64px 1fr; align-items:center; background:#FFFDFC;
-}
-.med .art{
-  width:56px;height:56px;border-radius:14px;border:1px solid var(--border);
-  background:#FFF; display:flex;align-items:center;justify-content:center;
-  box-shadow: var(--shadow-1); color: var(--sepia);
-}
-.med .art svg{ width:32px;height:32px; display:block; }
-.med .label{ font-weight:800; }
-.med .meta{ font-size:14px; color:var(--muted); }
-.med.armed .cardlet{ background:#F5FAF6; border-color:#D9EAD9; }
-.med.due .cardlet{ background:#FFF8E6; border-color:#F0E1B6; }
-.med.late .cardlet{ background:#FFF1F1; border-color:#F1C8C8; }
-.med.armed .art{ animation: medPulse 1500ms ease-in-out infinite; color: var(--sage); }
-.med.due .art{ animation: medGrow 900ms ease-in-out infinite alternate; color: var(--sage); }
-.med.late{ box-shadow: 0 0 0 3px color-mix(in oklab, var(--mauve) 38%, transparent); }
-.med.due{ box-shadow: 0 0 0 3px color-mix(in oklab, var(--sage) 40%, transparent); }
-.med.done{ opacity:.6; text-decoration: line-through; }
-@keyframes medGrow { from{ transform:scale(1);} to{ transform:scale(1.12);} }
-@keyframes medPulse{ 0%{ transform:scale(1);} 60%{ transform:scale(1.06);} 100%{ transform:scale(1);} }
-@media (prefers-reduced-motion: reduce){
-  .med .art { animation: none !important; }
-}
-
 /* ---- Schedules & dialog ---- */
 .schedule-actions{ display:flex; gap:8px; flex-wrap:wrap; }
 dialog.modal{
@@ -174,6 +132,159 @@ dialog.modal{
 
 /* Motion safe */
 @media (prefers-reduced-motion: reduce){ *,*::before,*::after{ transition:none !important; animation:none !important; } }
+/* === Tokens ============================================================= */
+:root{
+  /* palette */
+  --parchment:#F6F1EB;
+  --card:#FFFEFC;
+  --sepia:#4F3C2F;
+  --muted:#6E625B;
+  --sage:#7FB086;
+  --mauve:#9B8D88;
+  --border:#E7DED4;
+  --pill:#EEF4EC;
+  --railW: clamp(360px, 28vw, 460px);
+  --ring:#C7D7C5;
+  --soft:#F7F3EE;
+  --ink:#2E2A27;
+
+  /* layout + type */
+  --gap:16px;
+  --pad:16px;
+  --radius:18px;
+  --shadow-1: 0 1px 2px rgba(20,16,12,.06);
+  --shadow-2: 0 10px 28px rgba(20,16,12,.10);
+
+  --fs-xxs:11.5px;  /* AM/PM, tiny meta */
+  --fs-xs:13px;     /* chips, hints */
+  --fs-s:15px;      /* body */
+  --fs-m:17px;      /* buttons, dense labels */
+  --fs-l:22px;      /* section titles */
+  --fs-xl:40px;     /* weather temp */
+  --lh-tight:1.2;
+  --lh-base:1.45;
+}
+
+body{ font-size:16px; line-height:1.45; color:var(--sepia); }
+h1,h2,h3,.card-title{ letter-spacing:-.01em; }
+h2.section{ font-size:var(--fs-l); font-weight:700; }
+small,.meta{ font-size:var(--fs-xxs); color:var(--muted); }
+.num, .time-node .hhmm{ font-variant-numeric: tabular-nums; }
+
+/* helpers */
+.card{ background:var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:var(--shadow-1); padding:var(--pad); }
+.stack-8 > * + *{ margin-top:8px; }
+.stack-16 > * + *{ margin-top:16px; }
+.section-divider{ height:1px; background:color-mix(in oklab, var(--border), #000 5%); margin:12px 0; }
+.card{ background:var(--card); box-shadow: var(--shadow-1); }
+
+/* === Chips / Tags unified ============================================== */
+.chip, .tag{
+  display:inline-flex; align-items:center; gap:8px;
+  padding:6px 12px; border-radius:999px; font-size:var(--fs-xs);
+  background:var(--pill); border:1px solid var(--border); color:var(--sepia);
+}
+[aria-pressed="true"].chip{
+  background: color-mix(in oklab, var(--sage), #fff 85%);
+  border-color: color-mix(in oklab, var(--sage), #000 14%);
+}
+
+/* === Status banner ====================================================== */
+.status-banner{
+  position:sticky; top:8px; z-index:5;
+  display:flex; align-items:center; justify-content:space-between; gap:12px;
+  backdrop-filter:saturate(1.1) blur(8px);
+  background:color-mix(in oklab, var(--card), #ffffff 30%);
+  border:1px solid color-mix(in oklab, var(--border), #000 4%);
+  border-radius:24px; padding:10px 14px; box-shadow:var(--shadow-1);
+}
+.status-banner .left{ display:flex; align-items:center; gap:10px; }
+.status-dot{ width:8px; height:8px; border-radius:999px; background:#7FB086; }
+.status-banner .times{ font-weight:600; }
+.status-banner .btn-plus{
+  min-width:36px; height:36px; border-radius:12px;
+  background:var(--pill); border:1px solid var(--border); font-weight:700;
+}
+.status-banner.late  .status-dot{ background:#E46464; }
+.status-banner.tight .status-dot{ background:#E6A64E; }
+.status-banner.ok    .status-dot{ background:#7FB086; }
+.status-banner.tight .btn-plus,
+.status-banner.late  .btn-plus{
+  background: color-mix(in oklab, var(--sage), #fff 78%);
+}
+
+/* === Weather card ======================================================= */
+.weather header{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
+.weather .tools{ display:flex; align-items:center; gap:8px; }
+.weather-hero{ display:grid; grid-template-columns:auto 1fr; align-items:baseline; column-gap:12px; }
+.weather-hero .temp{ font-size:var(--fs-xl); font-weight:800; letter-spacing:-.015em; }
+.weather-hero .desc{ color:var(--muted); }
+
+.weather .foot{ margin-top:10px; color:var(--muted); font-size:var(--fs-xs); }
+
+/* windy hint via class on .weather */
+.weather.windy header .tag{ 
+  background: color-mix(in oklab, #DDEBF0, #fff 60%);
+  border-color: color-mix(in oklab, #B6D2DA, #000 8%);
+}
+
+/* === Leave plan ========================================================= */
+.leave-plan .label{ font-size:var(--fs-xs); color:var(--muted); margin-bottom:6px; }
+.leave-plan .row{ display:grid; grid-template-columns:1fr 1fr 1fr; gap:12px; }
+.input{
+  background:#FFFEFD; border:1px solid var(--border);
+  border-radius:12px; padding:10px 12px; height:44px;
+}
+.input:focus-visible{ outline:2px solid var(--sage); outline-offset:2px; }
+.hint{ color:var(--muted); font-size:var(--fs-xs); }
+
+/* === Timeline =========================================================== */
+.timeline{ position:relative; padding-left:20px; display:flex; flex-direction:column; gap:12px; }
+.timeline.dense{ gap:8px; }
+.timeline::before{
+  content:""; position:absolute; left:42px; top:0; bottom:0;
+  width:2px; background:linear-gradient(#EDE5DB, transparent 6px) repeat-y;
+  background-size:2px 14px; border-radius:2px;
+}
+.step{ display:grid; grid-template-columns:64px 1fr; gap:12px; align-items:center; }
+.time-node{
+  width:44px;height:44px;border-radius:999px;background:#FFF;border:1px solid var(--border); box-shadow:var(--shadow-1); display:flex; flex-direction:column; align-items:center; justify-content:center;
+}
+.time-node .hhmm{ font-weight:800; font-size:15px; }
+.time-node .ampm{ font-size:11px; color:var(--muted); margin-top:-2px; letter-spacing:.02em; }
+.cardlet{ background:#FCFAF7; border:1px solid var(--border); border-radius:16px; min-height:52px; padding:10px 12px; display:flex; align-items:flex-start; gap:12px; position:relative; }
+.cardlet .label{ font-weight:600; white-space:normal; }
+.cardlet .meta{ display:block; margin-top:2px; color:var(--muted); }
+.step.past .cardlet .meta{ display:none; }
+.step.now .cardlet{ border-color: color-mix(in oklab,var(--sage) 40%, var(--border)); box-shadow:0 0 0 2px color-mix(in oklab,var(--sage) 26%, transparent); }
+.step.past .cardlet{ opacity:.58; text-decoration:line-through; }
+.cardlet .actions{ margin-left:auto; display:flex; gap:6px; }
+.btn-icon{ width:28px;height:28px;padding:0;display:inline-flex;align-items:center;justify-content:center; }
+.step.done .time-node{background:var(--sage);color:#fff;border-color:var(--sage);}
+.step.done .cardlet{opacity:.6;text-decoration:line-through;}
+.cardlet.med{ background:#FFFDFC; }
+.cardlet.med.armed{ background:#F5FAF6; border-color:#D9EAD9; }
+.cardlet.med.due{   background:#FFF8E6; border-color:#F0E1B6; }
+.cardlet.med.late{  background:#FFF1F1; border-color:#F1C8C8; }
+.cardlet.med .bottle{ width:32px;height:32px; margin-right:6px; opacity:.95; }
+
+/* === Backpacks ========================================================== */
+.check-row{
+  display:grid; grid-template-columns:28px 1fr 28px; align-items:center;
+  height:56px; border-top:1px solid color-mix(in oklab, var(--border), #000 3%);
+}
+.check-row:first-child{ border-top:0; }
+.check-row button.del{ opacity:0; transition:opacity .12s; }
+.check-row:focus-within button.del{ opacity:1; }
+.checkbox{ width:24px; height:24px; border-radius:8px; border:1.5px solid var(--muted); }
+.checkbox:checked{ background:var(--sage); border-color:var(--sage); }
+
+/* === Motion ============================================================= */
+@media (prefers-reduced-motion:no-preference){
+  .btn-plus:active{ transform:translateY(1px) scale(.98); }
+  .step.now .cardlet{ transition: box-shadow .15s, border-color .15s; }
+  .chip{ transition: background-color .15s, border-color .15s; }
+}
   </style>
 </head>
 <body>
@@ -185,32 +296,32 @@ dialog.modal{
           <div class="today-date" id="todayDate">Today</div>
           <div class="today-tags">
             <!-- Only School remains; pressed=true means "School day" -->
-            <span class="tag" role="button" tabindex="0" aria-pressed="true" data-tag="school">School</span>
+            <span class="chip" role="button" tabindex="0" aria-pressed="true" data-tag="school">School</span>
             <button class="btn btn-ghost" id="quickAdd" aria-label="Quick add event">+ Event</button>
           </div>
         </section>
 
-        <section class="status-banner" role="region" aria-label="Status">
-          <div class="status-left">
-            <span class="dot" aria-hidden="true"></span>
-            <span id="pace">On pace</span>
+        <div class="status-banner ok" role="region" aria-label="Status">
+          <div class="left">
+            <span class="status-dot" role="img" aria-label="On pace"></span>
+            <span class="pace-text">On pace</span>
           </div>
-          <div>
-            <span>Shoes <b id="tShoes">8:25 AM</b> • Leave <b id="tLeave">8:30 AM</b></span>
-            <button id="add5" class="btn btn-ghost" title="Add 5 min buffer">+5</button>
+          <div class="times">
+            <span>Shoes <span id="shoesTime">8:25 AM</span></span> • <span>Leave <span id="leaveTime">8:30 AM</span></span>
           </div>
-        </section>
+          <button id="plus5" class="btn-plus" title="Add 5 min buffer">+5</button>
+        </div>
 
-        <section class="card weather-hero" aria-label="Weather">
-          <header class="card-head">
+        <section class="card weather" aria-label="Weather" id="weatherCard">
+          <header>
             <div class="card-title">Weather</div>
-            <div style="display:flex;align-items:center;gap:8px">
-              <div class="tag tag-sage" id="wxLocation">Hamilton</div>
+            <div class="tools">
+              <span class="tag" id="wxLocation">Hamilton</span>
               <button class="btn btn-ghost" id="wxRefresh" aria-label="Refresh weather" type="button">Refresh</button>
               <button class="btn btn-ghost" id="wxUseLoc" aria-label="Use my location">Use location</button>
-              </div>
+            </div>
           </header>
-          <div class="now"><div class="temp" id="wxNow">--°</div><div class="cond" id="wxCond">—</div></div>
+          <div class="weather-hero"><div class="temp" id="wxNow">--°</div><div class="desc" id="wxCond">—</div></div>
           <div class="stats">
             <div>H <b id="wxHi">--</b>°</div>
             <div>L <b id="wxLo">--</b>°</div>
@@ -221,22 +332,22 @@ dialog.modal{
           <div class="hint" id="wxCached" aria-live="polite" hidden>Showing cached weather</div>
         </section>
 
-        <section class="card" aria-label="Leave plan">
+        <section class="card leave-plan" aria-label="Leave plan">
           <header class="card-head">
             <div class="card-title">Leave plan</div>
             <div class="tag tag-sage" id="schoolState">School day</div>
           </header>
-          <div class="settings-grid">
+          <div class="row">
             <div class="field">
-              <label for="arrival">Arrival time</label>
+              <label for="arrival" class="label">Arrival time</label>
               <input id="arrival" type="time" value="08:45" />
             </div>
             <div class="field">
-              <label for="commute">Commute (min)</label>
+              <label for="commute" class="label">Commute (min)</label>
               <input id="commute" type="number" min="0" step="1" value="15" />
             </div>
             <div class="field">
-              <label for="shoesLead">Shoes lead (min)</label>
+              <label for="shoesLead" class="label">Shoes lead (min)</label>
               <input id="shoesLead" type="number" min="0" step="1" value="5" />
             </div>
           </div>
@@ -247,7 +358,7 @@ dialog.modal{
           <div class="hint">Buffers: rain +10, snow +15. Snow overrides rain. School's Out removes buffers.</div>
         </section>
 
-        <section class="card" aria-label="Backpacks">
+        <section class="card" aria-label="Backpacks" id="backpacks">
           <header class="card-head"><div class="card-title">Backpacks</div></header>
           <div class="backpack-grid" id="packs"></div>
           <div class="hint" style="margin-top:10px; display:flex; justify-content:space-between; align-items:center;">
@@ -291,7 +402,7 @@ dialog.modal{
               <button class="btn btn-ghost" id="toggleDense">Dense</button>
             </div>
           </header>
-          <div class="timeline" id="timeline"></div>
+          <div id="timeline"></div>
         </section>
       </div>
     </div>
@@ -401,10 +512,9 @@ dialog.modal{
   // ---------- Elements ----------
   const el={
     todayDate:document.getElementById('todayDate'),
-    pace:document.getElementById('pace'),
-    tShoes:document.getElementById('tShoes'),
-    tLeave:document.getElementById('tLeave'),
-    add5:document.getElementById('add5'),
+    tShoes:document.getElementById('shoesTime'),
+    tLeave:document.getElementById('leaveTime'),
+    plus5:document.getElementById('plus5'),
     wx:{ loc:document.getElementById('wxLocation'), now:document.getElementById('wxNow'), cond:document.getElementById('wxCond'), hi:document.getElementById('wxHi'), lo:document.getElementById('wxLo'), rain:document.getElementById('wxRain'), hours:document.getElementById('wxHours'), cached:document.getElementById('wxCached'), clothing:document.getElementById('clothing') },
     wxUseLoc:document.getElementById('wxUseLoc'),
     arrival:document.getElementById('arrival'),
@@ -432,14 +542,19 @@ dialog.modal{
     modalClose:document.getElementById('modalClose')
   };
 
-  document.querySelector('.status-banner')?.classList.add('is-sticky');
+  document.querySelectorAll('input[type="number"]').forEach(inp=>{
+    inp.setAttribute('inputmode','numeric');
+    inp.setAttribute('pattern','[0-9]*');
+    inp.classList.add('input');
+  });
+  el.arrival?.classList.add('input');
 
   // ---------- Init UI ----------
   el.todayDate.textContent=new Date().toLocaleDateString(undefined,{weekday:'long',month:'long',day:'numeric'});
   el.arrival.value=S.settings.arrival; el.commute.value=S.settings.commuteMins; el.shoesLead.value=S.settings.shoesLeadMins;
   el.schoolOut.checked=!currentFlags().schoolDay; updateSchoolVisual();
 
-  el.add5.onclick=()=>{currentFlags().extraBuffer+=5; save(); recomputeTimes()};
+  el.plus5.onclick=()=>{currentFlags().extraBuffer+=5; save(); recomputeTimes()};
   el.arrival.onchange=()=>{S.settings.arrival=el.arrival.value; save(); recomputeTimes()};
   el.commute.onchange=()=>{S.settings.commuteMins=+el.commute.value; save(); recomputeTimes()};
   el.shoesLead.onchange=()=>{S.settings.shoesLeadMins=+el.shoesLead.value; save(); recomputeTimes()};
@@ -474,6 +589,7 @@ dialog.modal{
   el.modalClose.onclick=()=>el.modal.close();
   if (el.addTask) el.addTask.onclick = addTaskInteractive;
   if (el.toggleDense) el.toggleDense.onclick = ()=> el.timeline.classList.toggle('dense');
+  document.querySelector('.status-banner')?.classList.add('is-sticky');
 
   recomputeTimes();
   renderTimeline();
@@ -528,6 +644,14 @@ dialog.modal{
     });
     el.wx.hours.appendChild(frag);
     el.wx.clothing.textContent='Clothing: '+clothingFor(W.code,W.now,W.rain,W.wind);
+    const card=document.querySelector('.weather');
+    if(card){
+      card.classList.toggle('windy',(S.wx?.wind??0)>=28);
+      const foot=card.querySelector('.foot')||card.appendChild(document.createElement('div'));
+      foot.className='foot';
+      const ts=S.wx?.lastUpdated?new Date(S.wx.lastUpdated):new Date();
+      foot.textContent=`Updated ${ts.toLocaleTimeString([], {hour:'numeric', minute:'2-digit'})}`;
+    }
   }
 
   function bufferByWeather(){ if(!currentFlags().schoolDay) return 0; const code=S.wx.code; if(isSnow(code)) return 15; if(isRain(code)) return 10; return 0 }
@@ -540,7 +664,12 @@ dialog.modal{
     const leave=minutesToHM(hmToMinutes(arr)-commute-buf-extra);
     const shoes=minutesToHM(hmToMinutes(leave)-shoesLead);
     el.tLeave.textContent=hmToStr12(leave); el.tShoes.textContent=hmToStr12(shoes);
-    updatePace(); renderTimeline(leave,shoes);
+    const shoesEl=document.getElementById('shoesTime');
+    const leaveEl=document.getElementById('leaveTime');
+    [shoesEl,leaveEl].forEach(el=>el&&el.closest('.times')?.classList.add('num'));
+    if(shoesEl) shoesEl.parentElement?.setAttribute('aria-label',`Shoes at ${shoesEl.textContent} ${/AM|PM/.test(shoesEl.textContent)?'':(S.localeAmPm||'AM/PM')}`);
+    if(leaveEl) leaveEl.parentElement?.setAttribute('aria-label',`Leave at ${leaveEl.textContent}`);
+    updatePace(); renderTimeline(leave,shoes); updateMedState();
   }
 
   function updatePace(){
@@ -548,38 +677,30 @@ dialog.modal{
     const leaveHM=parseHM24(el.tLeave.textContent);
     const minsToLeave=hmToMinutes(leaveHM)-(now.getHours()*60+now.getMinutes());
     let status='On pace'; if(minsToLeave<0) status='Late'; else if(minsToLeave<=10) status='Tight';
-    el.pace.textContent=status
+    const banner=document.querySelector('.status-banner');
+    if(!banner) return;
+    const paceText=banner.querySelector('.pace-text');
+    if(paceText) paceText.textContent=status;
+    const label=status.toLowerCase();
+    banner.classList.remove('late','tight','ok');
+    let state='ok';
+    if(label.includes('late')) state='late';
+    else if(label.includes('tight')) state='tight';
+    banner.classList.add(state);
+    const dot=banner.querySelector('.status-dot');
+    if(dot) dot.setAttribute('aria-label',state==='ok'?'On pace':state.charAt(0).toUpperCase()+state.slice(1));
   }
 
   // ---------- Timeline + Med states ----------
-  const MED_WARMUP_MIN = 10;
-  const MED_GRACE_MIN  = 5;
-
-  function medState(nowM, targetM, done){
-    if(done) return 'done';
-    const diff = targetM - nowM;
-    if(diff > MED_WARMUP_MIN) return 'idle';
-    if(diff > 0)              return 'armed';
-    if(diff >= -MED_GRACE_MIN)return 'due';
-    return 'late';
-  }
-
-  function updateMedStateFor(step){
-    const [hh,mm]=step.dataset.target.split(':').map(n=>+n); const targetM=hh*60+mm;
-    const now=new Date(); const nowM=now.getHours()*60+now.getMinutes();
-    const isDone=step.classList.contains('done');
-    const st=medState(nowM,targetM,isDone);
-    step.classList.remove('idle','armed','due','late','done');
-    step.classList.add(st);
-  }
-
-  function refreshMedStates(){ el.timeline.querySelectorAll('.step.med').forEach(updateMedStateFor); }
 
   function renderTimeline(leaveHM,shoesHM){
+    const rail=document.getElementById('timeline');
+    if(!rail) return;
+    rail.classList.add('timeline');
     const L=leaveHM||parseHM24(el.tLeave.textContent);
     const SH=shoesHM||parseHM24(el.tShoes.textContent);
     const tasks=[...S.todos].sort((a,b)=> taskStartMinutes(L,SH,a) - taskStartMinutes(L,SH,b));
-    el.timeline.innerHTML='';
+    rail.innerHTML='';
     const frag=document.createDocumentFragment();
     tasks.forEach(t=>{
       let start=null,end=null,label='';
@@ -592,36 +713,35 @@ dialog.modal{
       step.className='step'+(t.done?' done':'')+(t.special==='med'?' med':'');
       step.dataset.target=String(end.h).padStart(2,'0')+':'+String(end.m).padStart(2,'0');
 
-      const time=document.createElement('div'); time.className='time-node';
-      time.innerHTML=`<div class="hhmm">${timeHHMM(start)}</div><div class="ampm">${start.h<12?'AM':'PM'}</div>`;
+      const tn=document.createElement('div'); tn.className='time-node num';
+      tn.innerHTML=`<div class="hhmm">${timeHHMM(start)}</div><div class="ampm">${start.h<12?'AM':'PM'}</div>`;
 
       const card=document.createElement('div');
       if(t.special==='med'){
         card.className='cardlet med';
-        const art=document.createElement('div'); art.className='art'; art.innerHTML=BOTTLE_SVG;
+        const bottle=document.createElement('div'); bottle.className='bottle'; bottle.innerHTML=BOTTLE_SVG;
         const info=document.createElement('div'); info.innerHTML=`<div class="label">${escapeHtml(t.text)}</div><div class="meta">${label}</div>`;
-        card.append(art,info);
+        card.append(bottle,info);
         const actions=document.createElement('div'); actions.className='actions';
         const del=document.createElement('button'); del.className='btn btn-ghost btn-icon'; del.setAttribute('aria-label','Delete'); del.textContent='×';
-        del.onclick=()=>{ S.todos=S.todos.filter(x=>x!==t); save(); renderTimeline(L,SH); };
+        del.onclick=()=>{ S.todos=S.todos.filter(x=>x!==t); save(); renderTimeline(L,SH); updateMedState(); };
         actions.appendChild(del); card.appendChild(actions);
         card.onclick=()=>{ if(!t.done){ if(!confirm('Confirm medication taken?')) return; t.takenAt=new Date().toISOString() }
-          t.done=!t.done; save(); step.classList.toggle('done',t.done); updateMedStateFor(step); };
+          t.done=!t.done; save(); step.classList.toggle('done',t.done); updateMedState(); };
       } else {
         card.className='cardlet'; card.setAttribute('role','checkbox'); card.setAttribute('aria-checked',t.done?'true':'false');
-        card.innerHTML=`<span class="label">${escapeHtml(t.text)}</span><span class="meta">${label}</span>`;
+        card.innerHTML=`<div class="label">${escapeHtml(t.text)}</div><div class="meta">${label}</div>`;
         const actions=document.createElement('div'); actions.className='actions';
         const del=document.createElement('button'); del.className='btn btn-ghost btn-icon'; del.setAttribute('aria-label','Delete'); del.textContent='×';
-        del.onclick=()=>{ S.todos=S.todos.filter(x=>x!==t); save(); renderTimeline(L,SH); };
+        del.onclick=()=>{ S.todos=S.todos.filter(x=>x!==t); save(); renderTimeline(L,SH); updateMedState(); };
         actions.appendChild(del); card.appendChild(actions);
         card.onclick=()=>{ t.done=!t.done; save(); step.classList.toggle('done',t.done); card.setAttribute('aria-checked',t.done?'true':'false') };
       }
 
-      step.appendChild(time); step.appendChild(card); frag.appendChild(step);
+      step.appendChild(tn); step.appendChild(card); frag.appendChild(step);
     });
-    el.timeline.appendChild(frag);
+    rail.appendChild(frag);
     refreshTimelineStates();
-    refreshMedStates();
   }
 
   function refreshTimelineStates(){
@@ -638,26 +758,52 @@ dialog.modal{
     if(upNext>=0) rows[upNext].classList.add('now');
   }
 
+  function updateMedState(){
+    const med = S.todos.find(x=>x.special==='med');
+    if(!med) return;
+    let target;
+    if (med.abs) target = hmToMinutes(parseHM(med.abs));
+    else {
+      const L=parseHM24(el.tLeave.textContent), SH=parseHM24(el.tShoes.textContent);
+      if (med.rel==='leave') target = hmToMinutes(L)+(med.offset||0);
+      else if (med.rel==='shoes') target = hmToMinutes(SH)+(med.offset||0);
+    }
+    if (target==null) return;
+
+    const now = new Date(), nowM = now.getHours()*60 + now.getMinutes();
+    const diff = nowM - target;
+
+    let state = '';
+    if (diff < 0 && diff >= -10) state = 'armed';
+    else if (diff >= 0 && diff <= 5) state = 'due';
+    else if (diff > 5) state = 'late';
+
+    const node = el.timeline.querySelector('.cardlet.med');
+    if (!node) return;
+    node.classList.remove('armed','due','late');
+    if (state) node.classList.add(state);
+  }
+
   // ---------- Backpacks ----------
   function renderBackpacks(){
     const grid=el.packs; grid.innerHTML='';
     const fragAll=document.createDocumentFragment();
     [["onyx","Onyx"],["peregrine","Peregrine"]].forEach(([key,label])=>{
-      const card=document.createElement('div'); card.className='backpack-card';
+      const card=document.createElement('div'); card.className='card';
       const h=document.createElement('h3'); h.textContent=label; card.appendChild(h);
       const listFrag=document.createDocumentFragment();
       S.backpacks[key].forEach((item,idx)=>{
-        const row=document.createElement('div'); row.className='pack-row'+(item.done?' checked':'');
-        const cb=document.createElement('input'); cb.type='checkbox'; cb.id=`cb-${key}-${idx}`; cb.checked=item.done; cb.setAttribute('aria-labelledby',`txt-${key}-${idx}`);
-        cb.onchange=()=>{ item.done=cb.checked; row.classList.toggle('checked',item.done); save() };
+        const row=document.createElement('div'); row.classList.add('check-row');
+        const cb=document.createElement('input'); cb.type='checkbox'; cb.id=`cb-${key}-${idx}`; cb.checked=item.done; cb.classList.add('checkbox'); cb.setAttribute('aria-labelledby',`txt-${key}-${idx}`);
+        const text=document.createElement('div'); text.id=`txt-${key}-${idx}`; text.textContent=item.text; text.contentEditable='true';
+        text.style.opacity=item.done?0.55:1;
+        cb.onchange=()=>{ item.done=cb.checked; text.style.opacity=item.done?0.55:1; save() };
+        text.oninput=()=>{ item.text=text.textContent; save() };
 
-        const txt=document.createElement('div'); txt.id=`txt-${key}-${idx}`; txt.textContent=item.text; txt.contentEditable='true';
-        txt.oninput=()=>{ item.text=txt.textContent; save() };
-
-        const del=document.createElement('button'); del.className='btn btn-ghost btn-icon'; del.setAttribute('aria-label','Delete item'); del.textContent='×';
+        const del=document.createElement('button'); del.className='btn btn-ghost btn-icon del'; del.setAttribute('aria-label','Delete item'); del.textContent='×';
         del.onclick=()=>{ S.backpacks[key].splice(idx,1); save(); renderBackpacks(); };
 
-        row.append(cb, txt, del);
+        row.append(cb, text, del);
         listFrag.appendChild(row);
       });
 
@@ -695,7 +841,7 @@ dialog.modal{
       return (w.date===today) || (Array.isArray(w.dates) && w.dates.includes(today));
     }).forEach(r=>{
       const chip=document.createElement('button');
-      chip.className='tag';
+      chip.className='chip';
       chip.dataset.chip='rule';
       chip.textContent=r.title+(r.kid?` — ${capitalize(r.kid)}`:'');
       chip.onclick=()=>applyRuleInteractive(r);
@@ -746,7 +892,7 @@ dialog.modal{
     else if (/^\d{2}:\d{2}$/.test(w)){ task={id:'t'+Math.random().toString(36).slice(2),text,done:false,abs:w}; }
     else if (w.startsWith('leave')||w.startsWith('shoes')){ const [rel,offStr]=w.split(/\s+/); const offset=parseInt(offStr||'0',10); task={id:'t'+Math.random().toString(36).slice(2),text,done:false,rel,offset}; }
     else return alert('Unrecognized time format.');
-    S.todos.push(task); save(); recomputeTimes(); renderTimeline();
+    S.todos.push(task); save(); recomputeTimes(); renderTimeline(); updateMedState();
   }
 
   // ---------- Schedules (images) ----------
@@ -817,7 +963,7 @@ dialog.modal{
 
   // ---------- Ticking ----------
   function startMinuteAlignedTick(){
-    const tick=()=>{ updatePace(); refreshTimelineStates(); refreshMedStates(); renderRuleChips(); };
+    const tick=()=>{ updatePace(); refreshTimelineStates(); updateMedState(); renderRuleChips(); };
     tick();
     const delay=60000-(Date.now()%60000);
     setTimeout(()=>{ tick(); setInterval(tick,60000); }, delay);

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* sw.js */
-const SHELL = 'dc-shell-v14';
+const SHELL = 'dc-shell-v15';
 const DATA  = 'dc-data-v1';
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
## Summary
- Introduce warmer palette tokens, focus ring color, and softer weather mini cards
- Rework timeline hierarchy and medication states with new card styling and delete controls
- Add medication state machine and sticky status banner setup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d75012748323b778e254d693e5cc