### PR TITLE
feat: load external stylesheet and cache

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Daily Command — iPad Rail</title>
   <meta name="theme-color" content="#5C4433" />
+  <link rel="stylesheet" href="/styles.css" />
   <style>
 :root{
   --parchment:#F6F1EB;

--- a/sw.js
+++ b/sw.js
@@ -1,11 +1,11 @@
 /* sw.js */
-const SHELL = 'dc-shell-v17';
+const SHELL = 'dc-shell-v18';
 const DATA  = 'dc-data-v1';
 
 self.addEventListener('install', (e) => {
-  e.waitUntil(
-    caches.open(SHELL).then(c => c.addAll(['/', '/index.html']))
-  );
+    e.waitUntil(
+      caches.open(SHELL).then(c => c.addAll(['/', '/index.html', '/styles.css']))
+    );
 });
 
 self.addEventListener('activate', (e) => {


### PR DESCRIPTION
## Summary
- include the `styles.css` file via `<link>` in `index.html`
- cache `styles.css` and bump service worker shell version for offline support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b62b33c8b48323b5ef9ebb25ae003f