### PR TITLE
feat: redesign weather hero layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,13 +77,72 @@ body{
 :focus-visible{ outline:2px solid var(--ring); outline-offset:2px; border-radius:12px; }
 
 /* ---- Weather ---- */
-.weather-hero .now{ display:flex; align-items:baseline; gap:10px; }
-.weather-hero .temp{ font-size:40px; font-weight:800; }
-.weather-hero .cond{ font-size:17px; color:var(--muted); }
-.weather-hero .stats{ display:flex; gap:16px; color:var(--muted); margin-top:6px; }
-.weather-hero.loading .now,.weather-hero.loading .stats,.weather-hero.loading .weather-mini{ opacity:.5; }
-.weather-hero.loading .temp::after{
-  content:'…'; margin-left:6px; font-weight:700; opacity:.8;
+.weather-hero{
+  --paper:#F6F1EB;
+  --ink:#5C4433;
+  --sage:#7A8C5F;
+  --line:rgba(0,0,0,.06);
+  --temp-size:clamp(72px, 9vw, 124px);
+  --r:20px;
+  --pad:24px;
+  background:var(--paper);
+  border:1px solid var(--line);
+  border-radius:var(--r);
+  padding:var(--pad);
+  box-shadow:0 2px 8px rgba(0,0,0,.06);
+}
+
+.wx-grid{
+  display:grid;
+  grid-template-columns:minmax(320px, 1fr) 1fr;
+  gap:24px;
+  align-items:center;
+}
+
+.wx-lead{display:flex; flex-direction:column; gap:8px}
+.wx-lockup{display:flex; align-items:flex-end; gap:16px}
+
+.wx-temp{font-size:var(--temp-size); line-height:1; font-weight:800; color:var(--sage); letter-spacing:-0.02em}
+.wx-temp-unit{margin-left:2px}
+
+.wx-icon{
+  height:calc(var(--temp-size) * 0.96);
+  aspect-ratio:1/1;
+  object-fit:contain;
+  display:block;
+  margin-bottom:0;
+}
+
+.wx-cond{font-size:18px; color:var(--ink)}
+
+.wx-aside{display:flex; flex-direction:column; gap:12px}
+.wx-chips{display:flex; flex-wrap:wrap; gap:8px}
+.chip{
+  background:#fff; border:1px solid var(--line); border-radius:999px;
+  padding:6px 12px; font-size:14px; color:var(--ink)
+}
+.chip--ghost{background:transparent}
+
+.wx-stats{display:grid; grid-template-columns:repeat(2, minmax(120px,1fr)); gap:8px 16px}
+.wx-stats dt{font-size:12px; color:rgba(0,0,0,.55)}
+.wx-stats dd{font-size:16px; color:var(--ink); margin:0}
+
+.wx-hours{
+  margin-top:16px;
+  display:grid; grid-template-columns:repeat(5,1fr); gap:8px;
+  font-size:14px; color:var(--ink)
+}
+.wx-hours > div{
+  background:#fff; border:1px solid var(--line); border-radius:14px;
+  padding:8px 10px; text-align:center
+}
+.wx-dot{opacity:.35}
+
+.wx-updated{margin:10px 0 0; font-size:12px; color:rgba(0,0,0,.55)}
+
+@media (max-width: 980px){
+  .wx-grid{grid-template-columns:1fr}
+  .wx-aside{order:2}
 }
 
 /* ---- Leave plan ---- */
@@ -193,22 +252,8 @@ small,.meta{ font-size:var(--fs-xxs); color:var(--muted); }
   background: color-mix(in oklab, var(--sage), #fff 78%);
 }
 
-/* === Weather card ======================================================= */
-.weather header{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
-.weather .tools{ display:flex; align-items:center; gap:8px; }
-.weather-hero{ display:grid; grid-template-columns:auto 1fr; align-items:baseline; column-gap:12px; }
-.weather-hero .temp{ font-size:var(--fs-xl); font-weight:800; letter-spacing:-.015em; }
-.weather-hero .desc{ color:var(--muted); }
-.weather-mini{ display:grid; grid-template-columns:repeat(5,1fr); gap:10px; }
-.weather-mini .cell{
-  background:var(--pill); border:1px solid var(--border);
-  border-radius:12px; padding:10px 8px; text-align:center;
-}
-.weather-mini .t{ font-weight:600; }
-.weather .foot{ margin-top:10px; color:var(--muted); font-size:var(--fs-xs); }
-
-/* windy hint via class on .weather */
-.weather.windy header .tag{ 
+/* windy hint via class on .weather-hero */
+.weather-hero.windy .wx-chips .chip{
   background: color-mix(in oklab, #DDEBF0, #fff 60%);
   border-color: color-mix(in oklab, #B6D2DA, #000 8%);
 }
@@ -352,13 +397,6 @@ main,
 
 /* keep meds item larger and tinted */
 
-.wx-hero{
-  display:grid; grid-template-columns:1fr; justify-items:center; row-gap:6px;
-  margin-bottom:10px;
-}
-.wx-temp{ font-size:42px; font-weight:700; line-height:1; }
-.wx-icon{ font-size:42px; transform:translateY(-2px); }
-.wx-desc{ color:var(--ink-700); font-weight:500; }
 
 .leave-form{
   display:grid; grid-template-columns:1fr 110px 110px; gap:16px; align-items:end;
@@ -397,29 +435,36 @@ main,
           <button id="plus5" class="btn-plus" title="Add 5 min buffer">+5</button>
         </section>
 
-        <section class="card weather" aria-label="Weather" id="weatherCard">
-        <header>
-          <div class="card-title">Weather</div>
-          <div class="tools">
-            <span class="tag" id="wxLocation">Hamilton</span>
-            <button class="btn btn-ghost" id="wxRefresh" aria-label="Refresh weather" type="button">Refresh</button>
-            <button class="btn btn-ghost" id="wxUseLoc" aria-label="Use my location">Use location</button>
+        <section class="weather-hero" aria-label="Weather" id="weatherCard">
+          <div class="wx-grid">
+            <div class="wx-lead">
+              <div class="wx-lockup">
+                <div class="wx-temp" aria-label="Temperature">
+                  <span class="wx-temp-value" id="wxTempValue">--</span><span class="wx-temp-unit">°</span>
+                </div>
+                <img class="wx-icon" id="wx-icon" src="" alt="Condition icon" />
+              </div>
+              <div class="wx-cond" aria-label="Condition" id="wx-desc">—</div>
+            </div>
+            <aside class="wx-aside">
+              <div class="wx-chips">
+                <button class="chip" id="wxLocation">Hamilton</button>
+                <button class="chip" id="wxRefresh">Refresh</button>
+                <button class="chip chip--ghost" id="wxUseLoc">Use location</button>
+              </div>
+              <dl class="wx-stats">
+                <div><dt>Feels</dt><dd id="wxFeels">--°</dd></div>
+                <div><dt>Wind</dt><dd id="wxWind">-- km/h</dd></div>
+                <div><dt>Humidity</dt><dd id="wxHumidity">--%</dd></div>
+                <div><dt>Rain</dt><dd id="wxRain">--%</dd></div>
+              </dl>
+            </aside>
           </div>
-        </header>
-        <div class="wx-hero">
-          <div class="wx-temp" id="wx-temp">--°</div>
-          <div class="wx-icon" id="wx-icon" aria-hidden="true">🌡️</div>
-          <div class="wx-desc" id="wx-desc">—</div>
-        </div>
-        <div class="stats">
-          <div>H <b id="wxHi">--</b>°</div>
-          <div>L <b id="wxLo">--</b>°</div>
-          <div>Rain <b id="wxRain">--%</b></div>
-        </div>
-        <div class="weather-mini" id="wxHours" aria-label="Mini forecast 5 points"></div>
-        <div class="hint" id="clothing" aria-live="polite">Clothing: —</div>
-        <div class="hint" id="wxCached" aria-live="polite" hidden>Showing cached weather</div>
-      </section>
+          <div class="wx-hours" aria-label="Hourly" id="wxHours"></div>
+          <p class="wx-updated" id="wxUpdated">Updated --:--</p>
+          <div class="hint" id="clothing" aria-live="polite">Clothing: —</div>
+          <div class="hint" id="wxCached" aria-live="polite" hidden>Showing cached weather</div>
+        </section>
 
         <section class="card leave-plan" aria-label="Leave plan">
         <header class="card-head">
@@ -528,7 +573,7 @@ main,
   // ---------- Default state ----------
   const DEFAULT_STATE={
     settings:{ arrival:'08:45', commuteMins:15, shoesLeadMins:5, lat:43.2557, lon:-79.8711, place:'Hamilton' },
-    wx:{now:null,high:null,low:null,rain:null,wind:null,code:null,desc:'',icon:'⛅',hours:[],lastUpdated:null},
+    wx:{now:null,feels:null,wind:null,humidity:null,rain:null,code:null,desc:'',hours:[],lastUpdated:null},
     events:[],
     backpacks:{
       onyx:[{text:'Lunch',done:false},{text:'Love note',done:false},{text:'Water bottle',done:false},{text:'Forms',done:false},{text:'Agenda',done:false}],
@@ -608,7 +653,7 @@ main,
     tShoes:document.getElementById('shoesTime'),
     tLeave:document.getElementById('leaveTime'),
     plus5:document.getElementById('plus5'),
-    wx:{ loc:document.getElementById('wxLocation'), temp:document.getElementById('wx-temp'), icon:document.getElementById('wx-icon'), desc:document.getElementById('wx-desc'), hi:document.getElementById('wxHi'), lo:document.getElementById('wxLo'), rain:document.getElementById('wxRain'), hours:document.getElementById('wxHours'), cached:document.getElementById('wxCached'), clothing:document.getElementById('clothing') },
+    wx:{ loc:document.getElementById('wxLocation'), tempVal:document.getElementById('wxTempValue'), icon:document.getElementById('wx-icon'), desc:document.getElementById('wx-desc'), feels:document.getElementById('wxFeels'), wind:document.getElementById('wxWind'), humidity:document.getElementById('wxHumidity'), rain:document.getElementById('wxRain'), hours:document.getElementById('wxHours'), cached:document.getElementById('wxCached'), clothing:document.getElementById('clothing'), updated:document.getElementById('wxUpdated') },
     wxUseLoc:document.getElementById('wxUseLoc'),
     arrival:document.getElementById('arrival'),
     commute:document.getElementById('commute'),
@@ -703,13 +748,26 @@ main,
   async function fetchWeather(){
     document.querySelector('.weather-hero')?.classList.add('loading');
     const {lat,lon}=S.settings; const tz=Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const params=new URLSearchParams({latitude:lat,longitude:lon,timezone:tz,current_weather:'true',hourly:'temperature_2m,precipitation_probability,wind_speed_10m,weathercode',daily:'temperature_2m_max,temperature_2m_min'});
+    const params=new URLSearchParams({latitude:lat,longitude:lon,timezone:tz,current_weather:'true',hourly:'temperature_2m,precipitation_probability,wind_speed_10m,weathercode,relativehumidity_2m,apparent_temperature',daily:'temperature_2m_max,temperature_2m_min'});
     const url='https://api.open-meteo.com/v1/forecast?'+params.toString();
     let ok=true,data;
     try{ const res=await fetch(url,{cache:'no-store'}); ok=res.ok; data=await res.json() }catch(e){ ok=false }
     if(ok&&data){
-      const h=data.hourly; const c=data.current_weather; const d=data.daily; const idx8=hourIndex(h.time,8); const r8=idx8>=0?h.precipitation_probability[idx8]:0;
-      S.wx={ now:Math.round(c.temperature), high:Math.round(d.temperature_2m_max[0]), low:Math.round(d.temperature_2m_min[0]), rain:r8, wind:Math.round(c.windspeed), code:c.weathercode, desc:wxDesc(c.weathercode), icon:wxIcon(c.weathercode), hours:sliceHours(h), lastUpdated:new Date().toISOString() };
+      const h=data.hourly; const c=data.current_weather; const d=data.daily;
+      const idx8=hourIndex(h.time,8);
+      const idxNow=hourIndex(h.time,new Date().getHours());
+      const r8=idx8>=0?h.precipitation_probability[idx8]:0;
+      S.wx={
+        now:Math.round(c.temperature),
+        feels:idxNow>=0?Math.round(h.apparent_temperature[idxNow]):null,
+        wind:Math.round(c.windspeed),
+        humidity:idxNow>=0?Math.round(h.relativehumidity_2m[idxNow]):null,
+        rain:r8,
+        code:c.weathercode,
+        desc:wxDesc(c.weathercode),
+        hours:sliceHours(h),
+        lastUpdated:new Date().toISOString()
+      };
       save(); el.wx.cached.hidden=true
     } else { el.wx.cached.hidden=false }
     document.querySelector('.weather-hero')?.classList.remove('loading');
@@ -725,37 +783,37 @@ main,
     return Array.from(map.values());
   }
 
-  const WX_ICON=[[/thunder|storm/i,"⛈️"],[/snow|sleet|flurr/i,"❄️"],[/rain|shower/i,"🌧️"],[/hail/i,"🌨️"],[/fog|mist|haze/i,"🌫️"],[/overcast|cloudy/i,"☁️"],[/partly|mostly\s*clear|few clouds/i,"⛅️"],[/clear|sunny/i,"☀️"]];
-  function pickWxIcon(desc){ for(const [re,icon] of WX_ICON){ if(re.test(desc)) return icon; } return "🌡️"; }
+  function emojiSrc(emoji){
+    const svg=`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>${emoji}</text></svg>`;
+    return 'data:image/svg+xml,'+encodeURIComponent(svg);
+  }
 
   function renderWeather(){
     const W=S.wx;
-    el.wx.temp.textContent=(W.now??'--')+'°';
+    el.wx.tempVal.textContent=(W.now??'--');
     el.wx.desc.textContent=W.desc||'—';
-    el.wx.icon.textContent=pickWxIcon(W.desc||'');
-    el.wx.hi.textContent=(W.high??'--');
-    el.wx.lo.textContent=(W.low??'--');
+    el.wx.icon.src=emojiSrc(wxIcon(W.code));
+    el.wx.icon.alt=W.desc||'';
+    el.wx.feels.textContent=(W.feels??'--')+'°';
+    el.wx.wind.textContent=(W.wind??'--')+' km/h';
+    el.wx.humidity.textContent=(W.humidity??'--')+'%';
     el.wx.rain.textContent=(W.rain??'--')+'%';
     el.wx.loc.textContent=S.settings.place||'—';
     const picks=[7,10,13,16,19];
     el.wx.hours.innerHTML='';
     const frag=document.createDocumentFragment();
     picks.forEach(h=>{
-      const itm=W.hours.find(x=>x?.hr===h) || {hr:h,temp:null,pop:null,code:null};
-      const cell=document.createElement('div'); cell.className='cell';
-      cell.innerHTML=`<div class="t">${hrLabel12(h)}</div><div class="v">${wxIcon(itm.code)} ${itm.temp??'--'}°</div><div class="t">${(itm.pop??'--')}%</div>`;
+      const itm=W.hours.find(x=>x?.hr===h) || {hr:h,temp:null};
+      const cell=document.createElement('div');
+      cell.innerHTML=`<time>${hrLabel12(h)}</time><span>${itm.temp??'--'}°</span><span class="wx-dot" aria-hidden="true">•</span>`;
       frag.appendChild(cell);
     });
     el.wx.hours.appendChild(frag);
     el.wx.clothing.textContent='Clothing: '+clothingFor(W.code,W.now,W.rain,W.wind);
-    const card=document.querySelector('.weather');
-    if(card){
-      card.classList.toggle('windy',(S.wx?.wind??0)>=28);
-      const foot=card.querySelector('.foot')||card.appendChild(document.createElement('div'));
-      foot.className='foot';
-      const ts=S.wx?.lastUpdated?new Date(S.wx.lastUpdated):new Date();
-      foot.textContent=`Updated ${ts.toLocaleTimeString([], {hour:'numeric', minute:'2-digit'})}`;
-    }
+    const ts=W.lastUpdated?new Date(W.lastUpdated):new Date();
+    el.wx.updated.textContent=`Updated ${ts.toLocaleTimeString([], {hour:'numeric', minute:'2-digit'})}`;
+    const card=document.querySelector('.weather-hero');
+    card?.classList.toggle('windy',(W.wind??0)>=28);
   }
 
   function bufferByWeather(){ if(!currentFlags().schoolDay) return 0; const code=S.wx.code; if(isSnow(code)) return 15; if(isRain(code)) return 10; return 0 }


### PR DESCRIPTION
## Summary
- Redesign weather hero with large left-aligned temperature and adjacent icon
- Add chips and quick stats on right plus slim hourly strip
- Fetch feels-like, wind, humidity stats and render updated weather UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bab50843cc832385d02fbc5e9ecae5